### PR TITLE
Os 구분하여 연결 처리될수 있도록 옵션 추가

### DIFF
--- a/app/custom_modules/router/scanner/serial.js
+++ b/app/custom_modules/router/scanner/serial.js
@@ -2,6 +2,10 @@
 function Scanner() {
 }
 
+function checkObject(target) {
+	return Object.prototype.toString.call(target) === '[object Object]';
+}
+
 Scanner.prototype.startScan = function(extension, config, callback, router) {
 	var serialport = require('../../serialport');
 	var self = this;
@@ -40,13 +44,26 @@ Scanner.prototype.scan = function(serialport, extension, config, callback) {
 		var serverMode = config.serverMode;
 		var scanType = config.hardware.scanType;
 		var vendor = config.hardware.vendor;
+
+		if(vendor && checkObject(vendor)) {
+			vendor = vendor[process.platform];
+		}
+
 		var control = config.hardware.control;
 		var duration = config.hardware.duration;
 		var firmwarecheck = config.hardware.firmwarecheck;
 		var pnpId = config.hardware.pnpId;
 		var type = config.hardware.type;
-		var checkComPort = (config.select_com_port || type === 'bluetooth' || serverMode === 1) || false;
+		var selectComPort = config.select_com_port;
+
+		if(selectComPort && checkObject(selectComPort)) {
+			selectComPort = selectComPort[process.platform];
+		}
+
+		var checkComPort = (selectComPort || type === 'bluetooth' || serverMode === 1) || false;
 		var myComPort = config.this_com_port;
+
+		
 
 		if(checkComPort && !myComPort)  {
 			self.router.emit('state', 'select_port', devices);

--- a/app/modules/entry.json
+++ b/app/modules/entry.json
@@ -21,6 +21,10 @@
         "translate": "Bluetooth driver"
     }],
     "reconnect" : true,
+    "select_com_port": {
+        "win32": false,
+        "darwin": true
+    },
     "firmware": [{
         "name": "entry",
         "translate": "Install Firmware(Sensor Board)"
@@ -35,7 +39,9 @@
         "type": "serial",
         "control": "slave",
         "duration": 32,
-        "vendor": ["wch.cn", "Arduino"],
+        "vendor": {
+            "win32": ["wch.cn", "Arduino"]
+        },
         "baudRate": 57600
     }
 }


### PR DESCRIPTION
e-센서보드 맥용 드라이버가 vendor 명을 제대로 처리 하지 못하여 

os 별로 처리 할수 있는 옵션을 생성하여 추가함.