### PR TITLE
[feature] 하드웨어 리스트 로드 방식 개선

### DIFF
--- a/app/src/main/core/functions/downloadModule.ts
+++ b/app/src/main/core/functions/downloadModule.ts
@@ -9,7 +9,7 @@ import directoryPaths from '../directoryPaths';
 
 const logger = createLogger('DownloadModule');
 
-const downloadModuleFunction = (moduleName: string) =>
+const downloadModuleFunction = (moduleName: string): Promise<IHardwareConfig> =>
     new Promise((resolve, reject) => {
         if (!moduleName) {
             reject('must be present moduleName');

--- a/app/src/main/core/functions/getModuleList.ts
+++ b/app/src/main/core/functions/getModuleList.ts
@@ -11,7 +11,10 @@ const getModuleListFunction: () => Promise<IOnlineHardwareConfig[]> = () => new 
 
     request.on('response', (response) => {
         let buffer = '';
-        response.on('error', reject);
+        response.on('error', (e: Error) => {
+            logger.warn('get module list from online failed, ', e);
+            resolve([]);
+        });
         response.on('data', (chunk) => {
             buffer += chunk.toString();
         });
@@ -27,7 +30,10 @@ const getModuleListFunction: () => Promise<IOnlineHardwareConfig[]> = () => new 
             }
         });
     });
-    request.on('error', reject);
+    request.on('error', ((e) => {
+        logger.warn('get module list from online failed, ', e);
+        resolve([]);
+    }));
     request.end();
 });
 

--- a/app/src/main/mainRouter.ts
+++ b/app/src/main/mainRouter.ts
@@ -79,8 +79,6 @@ class MainRouter {
         this.registerIpcEvents();
 
         this.hardwareListManager.updateHardwareList();
-        this.hardwareListManager.updateHardwareListWithOnline();
-
         logger.verbose('mainRouter created');
     }
 
@@ -522,8 +520,7 @@ class MainRouter {
     async requestHardwareModule(moduleName: string) {
         logger.info(`hardware module requested from online, moduleName : ${moduleName}`);
         const moduleConfig = await downloadModule(moduleName);
-        this.hardwareListManager.updateHardwareList([moduleConfig]);
-        await this.hardwareListManager.updateHardwareListWithOnline();
+        await this.hardwareListManager.updateHardwareList([moduleConfig]);
     }
 
     private resetIpcEvents() {


### PR DESCRIPTION
### 어떤 종류의 PR 인가요?

- [ ] 신규 하드웨어 추가
- [ ] 기존 하드웨어 변경
- [x] 기타

### 이 PR 에서 어떤 부분이 변경되었나요? (작성필요)

- 로컬 디바이스 목록 로드 / 온라인 디바이스 목록 로드의 로직을 하나의 메소드에서 수행하도록 개선
- HardwareListManager 내에서 any 타입으로 동작하던 로직들에 타입 부여
- into develop 이지만, develop-hw + 추가커밋 으로 이루어져 있습니다. 아래 두개의 커밋만 보셔도 됩니다.
  - https://github.com/entrylabs/entry-hw/commit/c343b858f9ded815f1b0717746fdaa005ad87bbc
  - https://github.com/entrylabs/entry-hw/commit/eb35f7633cdd17c053cf6028f464fbfc25052aec

### PR 에 대해 아래 부분을 확인해주세요

- [x] 코드 문법 오류가 발생하진 않았는가
- [x] 코딩 컨벤션을 정리했는가 (린트, 들여쓰기, 등등..)
- [ ] base branch 설정을 develop-hw 으로 했는가?
- [x] PR 생성 후, 기존 코드와 충돌이 나진 않았나요?
