### PR TITLE
로보토리 USB to Serial 모듈 Silicon Lab CP2102칩 지원추가

### DIFF
--- a/app/modules/robotori.json
+++ b/app/modules/robotori.json
@@ -19,7 +19,7 @@
         "type": "serial",
         "control": "slave",
         "duration": 32,
-        "vendor": "Prolific",
+        "vendor": ["Prolific","Silicon Lab"],
         "baudRate": 38400,
         "firmwarecheck": false
     }


### PR DESCRIPTION
#### 유의사항

- base Branch 는 develop-hw 로 통일하였습니다. master, develop 이 아닙니다.
- 체크박스의 체크는 이슈 생성 후 직접 클릭 or [x] 와 같이 체크하면 됩니다.

### 어떤 하드웨어 인가요?

> [하드웨어명 / 회사명]
   로보토리 / 라이프앤사이언스

### 어떤 종류의 PR 인가요?

- [ ] 신규 하드웨어 추가
- [x] 기존 하드웨어 변경
- [ ] 기타

### 이 PR 에서 어떤 부분이 변경되었나요? (작성필요)

- USB to Serial 모듈을 기존 Prolific만 지원 하던 것을 Silicon Lab도 지원되게 수정
- ...

### PR 에 대해 아래 부분을 확인해주세요

- [x] 코드 문법 오류가 발생하진 않았는가 
- [x] 코딩 컨벤션을 정리했는가 (린트, 들여쓰기, 등등..) 
- [x] base branch 설정을 develop-hw 으로 했는가?
- [x] PR 생성 후, 기존 코드와 충돌이 나진 않았나요?
