### PR TITLE
Issue/5753

### DIFF
--- a/app/src/main/electron/index.ts
+++ b/app/src/main/electron/index.ts
@@ -13,7 +13,6 @@ import registerGlobalShortcut from './functions/registerGlobalShortcut';
 import checkUpdate from './functions/checkUpdate';
 import MainRouter from '../mainRouter.build';
 import createLogger from './functions/createLogger';
-import isValidAsarFile from './modifyValidator';
 
 const logger = createLogger('electron/index.ts');
 
@@ -128,18 +127,6 @@ if (!app.requestSingleInstanceLock()) {
                 mainRouter.selectHardware(autoOpenHardwareId);
             }, 1000);
         }
-
-        setTimeout(async () => {
-            try {
-                const result = await isValidAsarFile();
-                if (!result) {
-                    mainWindow?.webContents.send('invalidAsarFile');
-                }
-            } catch (e) {
-                console.log(e);
-                mainWindow?.webContents.send('invalidAsarFile');
-            }
-        }, 2000);
     });
 
     ipcMain.on('hardwareForceClose', () => {

--- a/app/src/main/mainRouter.ts
+++ b/app/src/main/mainRouter.ts
@@ -537,18 +537,14 @@ class MainRouter {
             this.flasher.kill();
             this.config && this.startScan(this.config);
         });
-        ipcMain.handle('invalidAsarFile', async (event) => {
+        ipcMain.handle('isValidAsarFile', async (event) => {
             try {
                 const result = await isValidAsarFile();
                 console.log("isValidAsarFile : ", result);
-                if (!result) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return result;
             } catch (e) {
                 console.log(e);
-                return true;
+                return false;
             }
         })
         ipcMain.on('getSharedObject', (e) => {

--- a/app/src/main/mainRouter.ts
+++ b/app/src/main/mainRouter.ts
@@ -13,6 +13,7 @@ import directoryPaths from './core/directoryPaths';
 import BaseScanner from './core/baseScanner';
 import BaseConnector from './core/baseConnector';
 import SerialConnector from './core/serial/connector';
+import isValidAsarFile from './electron/modifyValidator';
 
 const nativeNodeRequire = require('./nativeNodeRequire.js');
 const logger = createLogger('core/mainRouter.ts');
@@ -239,7 +240,7 @@ class MainRouter {
                 if (connector) {
                     logger.info(
                         `[Device Info] ${config.id} | ${
-                            config?.name?.ko || config?.name?.en || 'noname'
+                        config?.name?.ko || config?.name?.en || 'noname'
                         }`
                     );
                     this.connector = connector;
@@ -536,11 +537,25 @@ class MainRouter {
             this.flasher.kill();
             this.config && this.startScan(this.config);
         });
+        ipcMain.handle('invalidAsarFile', async (event) => {
+            try {
+                const result = await isValidAsarFile();
+                console.log("isValidAsarFile : ", result);
+                if (!result) {
+                    return true;
+                } else {
+                    return false;
+                }
+            } catch (e) {
+                console.log(e);
+                return true;
+            }
+        })
         ipcMain.on('getSharedObject', (e) => {
             e.returnValue = global.sharedObject;
         });
         ipcMain.on('canShowCustomButton', (e) => {
-            if(this.hwModule && this.hwModule.canShowCustomButton) {
+            if (this.hwModule && this.hwModule.canShowCustomButton) {
                 e.returnValue = this.hwModule.canShowCustomButton();
             } else {
                 e.returnValue = false;

--- a/app/src/renderer/react/main/components/IpcRendererWatchComponent.tsx
+++ b/app/src/renderer/react/main/components/IpcRendererWatchComponent.tsx
@@ -29,9 +29,11 @@ class IpcRendererWatchComponent extends React.PureComponent<IProps> {
         ipcRenderer.removeAllListeners('socketConnected');
         ipcRenderer.removeAllListeners('invalidAsarFile');
 
-        ipcRenderer.on('invalidAsarFile', () => {
-            props.invalidateBuild();
-        });
+        ipcRenderer.invoke('invalidAsarFile').then((result: boolean) => {
+            if(result){
+                props.invalidateBuild();
+            }
+        })
 
         ipcRenderer.on('console', (event, ...args: any[]) => {
             console.log(...args);

--- a/app/src/renderer/react/main/components/IpcRendererWatchComponent.tsx
+++ b/app/src/renderer/react/main/components/IpcRendererWatchComponent.tsx
@@ -27,10 +27,9 @@ class IpcRendererWatchComponent extends React.PureComponent<IProps> {
         ipcRenderer.removeAllListeners('portListScanned');
         ipcRenderer.removeAllListeners('cloudMode');
         ipcRenderer.removeAllListeners('socketConnected');
-        ipcRenderer.removeAllListeners('invalidAsarFile');
 
-        ipcRenderer.invoke('invalidAsarFile').then((result: boolean) => {
-            if(result){
+        ipcRenderer.invoke('isValidAsarFile').then((result: boolean) => {
+            if(!result){
                 props.invalidateBuild();
             }
         })


### PR DESCRIPTION
- https://oss.navercorp.com/entry/entry2/issues/5753
- renderer 리스너가 올려지기 전에 main에서 이벤트를 디스패치하는 경우가 있어서 수정하였습니다.
- renderer에서 listen하고 main에서 먼저 ipc 요청을 보내는 방식에서 => renderer 에서 먼저 invoke하고 main의 ipcMain이 handle하도록 수정